### PR TITLE
Hooks API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinypg",
-  "version": "4.1.0",
+  "version": "4.2.0-alpha.1",
   "description": "Easy way to call sql files using postgres.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinypg",
-  "version": "4.2.0-alpha.5",
+  "version": "4.2.0-alpha.6",
   "description": "Easy way to call sql files using postgres.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinypg",
-  "version": "4.2.0-alpha.6",
+  "version": "4.2.0-alpha.7",
   "description": "Easy way to call sql files using postgres.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinypg",
-  "version": "4.2.0-beta.2",
+  "version": "4.2.0",
   "description": "Easy way to call sql files using postgres.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinypg",
-  "version": "4.2.0-alpha.2",
+  "version": "4.2.0-alpha.3",
   "description": "Easy way to call sql files using postgres.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinypg",
-  "version": "4.2.0-alpha.9",
+  "version": "4.2.0-beta.1",
   "description": "Easy way to call sql files using postgres.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinypg",
-  "version": "4.2.0-alpha.1",
+  "version": "4.2.0-alpha.2",
   "description": "Easy way to call sql files using postgres.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinypg",
-  "version": "4.2.0-beta.1",
+  "version": "4.2.0-beta.2",
   "description": "Easy way to call sql files using postgres.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinypg",
-  "version": "4.2.0-alpha.7",
+  "version": "4.2.0-alpha.8",
   "description": "Easy way to call sql files using postgres.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinypg",
-  "version": "4.2.0-alpha.3",
+  "version": "4.2.0-alpha.4",
   "description": "Easy way to call sql files using postgres.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinypg",
-  "version": "4.2.0-alpha.4",
+  "version": "4.2.0-alpha.5",
   "description": "Easy way to call sql files using postgres.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinypg",
-  "version": "4.2.0-alpha.8",
+  "version": "4.2.0-alpha.9",
   "description": "Easy way to call sql files using postgres.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { TinyPg } from './tiny'
 
 export { TinyPg, FormattableDbCall } from './tiny'
 
-export { Result, TinyPgOptions, QueryBeginContext, QueryCompleteContext, SqlParseResult, SqlFile, TinyPgParams } from './types'
+export { Result, TinyPgOptions, QueryBeginContext, QueryCompleteContext, SqlParseResult, SqlFile, TinyPgParams, TinyCallContext } from './types'
 
 export { TinyPgError, TinyPgErrorTransformer } from './errors'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { TinyPg } from './tiny'
 
 export { TinyPg, FormattableDbCall } from './tiny'
 
-export { Result, TinyPgOptions, QueryBeginContext, QueryCompleteContext, SqlParseResult, SqlFile } from './types'
+export { Result, TinyPgOptions, QueryBeginContext, QueryCompleteContext, SqlParseResult, SqlFile, TinyPgParams } from './types'
 
 export { TinyPgError, TinyPgErrorTransformer } from './errors'
 

--- a/src/test/hooks.ts
+++ b/src/test/hooks.ts
@@ -350,6 +350,30 @@ describe('Hooks', () => {
                }
             })
          })
+
+         describe('and there is an error in the query', () => {
+            it('should still call onResult with a complete context', async () => {
+               let final_context: any
+               const hooks: TinyHooks = {
+                  onResult(ctx, query_complete_context) {
+                     final_context = { ...ctx, onResult: query_complete_context }
+                     return final_context
+                  },
+               }
+
+               const hooks_creation_methods = [H.newTiny({ hooks: hooks }), tiny.withHooks(hooks)]
+
+               for (const my_tiny of hooks_creation_methods) {
+                  final_context = null
+
+                  try {
+                     await my_tiny.query('SELECT BOOM FROM POW')
+                  } catch {}
+
+                  expect(final_context.onResult.error).to.exist
+               }
+            })
+         })
       })
    })
 

--- a/src/test/hooks.ts
+++ b/src/test/hooks.ts
@@ -11,14 +11,16 @@ AsyncHooks.createHook({ init() {} }).enable()
 describe('Hooks', () => {
    let tiny: TinyPg
 
-   beforeEach(() => {
+   beforeEach(async () => {
       tiny = H.newTiny()
 
-      return H.setUpDb().then(() => {
-         return ['a', 'b', 'c'].reduce((chain, v) => {
-            return chain.then<any>(() => H.insertA(v))
-         }, Promise.resolve())
-      })
+      await H.setUpDb()
+
+      const text = ['a', 'b', 'c']
+
+      for (const letter of text) {
+         await H.insertA(letter)
+      }
    })
 
    describe('preSql', () => {

--- a/src/test/hooks.ts
+++ b/src/test/hooks.ts
@@ -1,0 +1,49 @@
+import * as H from './helper'
+import { expect } from 'chai'
+import { TinyPg } from '../'
+
+describe.only('Hooks', () => {
+   let tiny: TinyPg
+
+   beforeEach(() => {
+      tiny = H.newTiny()
+
+      return H.setUpDb().then(() => {
+         return ['a', 'b', 'c'].reduce((chain, v) => {
+            return chain.then<any>(() => H.insertA(v))
+         }, Promise.resolve())
+      })
+   })
+
+   describe('preSql', () => {
+      describe('options', () => {})
+      describe('withHooks', () => {
+         it('should thread context', async () => {
+            let final_context = null
+
+            const my_tiny = tiny.withHooks({
+               preSql: (ctx, name, params) => {
+                  return { ctx: { ...ctx, foo: 'bar' }, args: [name, params] }
+               },
+               onQuery(ctx, query_begin_context) {
+                  return { ...ctx, onQuery: query_begin_context }
+               },
+               onSubmit(ctx, query_submit_context) {
+                  return { ...ctx, onSubmit: query_submit_context }
+               },
+               onResult(ctx, query_complete_context) {
+                  final_context = { ...ctx, onResult: query_complete_context }
+                  return final_context
+               },
+            })
+
+            await my_tiny.sql('a.select')
+
+            expect(final_context.foo).to.equal('bar')
+            expect(final_context.onQuery).to.not.be.null
+            expect(final_context.onSubmit).to.not.be.null
+            expect(final_context.onResult).to.not.be.null
+         })
+      })
+   })
+})

--- a/src/test/hooks.ts
+++ b/src/test/hooks.ts
@@ -42,7 +42,7 @@ describe('Hooks', () => {
             })
 
             await my_tiny.sql('a.select')
-            console.log(final_context)
+
             expect(final_context.foo).to.equal('bar')
             expect(final_context.onQuery).to.exist
             expect(final_context.onSubmit).to.exist

--- a/src/test/hooks.ts
+++ b/src/test/hooks.ts
@@ -42,11 +42,11 @@ describe('Hooks', () => {
             })
 
             await my_tiny.sql('a.select')
-
+            console.log(final_context)
             expect(final_context.foo).to.equal('bar')
-            expect(final_context.onQuery).to.not.be.null
-            expect(final_context.onSubmit).to.not.be.null
-            expect(final_context.onResult).to.not.be.null
+            expect(final_context.onQuery).to.exist
+            expect(final_context.onSubmit).to.exist
+            expect(final_context.onResult).to.exist
          })
       })
    })

--- a/src/test/hooks.ts
+++ b/src/test/hooks.ts
@@ -1,6 +1,7 @@
 import * as H from './helper'
 import { expect } from 'chai'
 import { TinyPg } from '../'
+import * as AsyncHooks from 'async_hooks'
 
 describe.only('Hooks', () => {
    let tiny: TinyPg
@@ -44,6 +45,40 @@ describe.only('Hooks', () => {
             expect(final_context.onSubmit).to.not.be.null
             expect(final_context.onResult).to.not.be.null
          })
+      })
+   })
+
+   describe('with async_hooks', () => {
+      let final_context = null
+      let hooked_tiny = null
+
+      beforeEach(() => {
+         hooked_tiny = tiny.withHooks({
+            preSql: (ctx, name, params) => {
+               return {
+                  ctx: { ...ctx, preSql: { async_id: AsyncHooks.executionAsyncId(), trigger_id: AsyncHooks.triggerAsyncId() } },
+                  args: [name, params],
+               }
+            },
+            onQuery(ctx) {
+               return { ...ctx, onQuery: { async_id: AsyncHooks.executionAsyncId(), trigger_id: AsyncHooks.triggerAsyncId() } }
+            },
+            onSubmit(ctx) {
+               return { ...ctx, onSubmit: { async_id: AsyncHooks.executionAsyncId(), trigger_id: AsyncHooks.triggerAsyncId() } }
+            },
+            onResult(ctx) {
+               final_context = { ...ctx, onResult: { async_id: AsyncHooks.executionAsyncId(), trigger_id: AsyncHooks.triggerAsyncId() } }
+               return final_context
+            },
+         })
+      })
+
+      it('should run preSql in the same execution context', async () => {
+         const caller_async_execution_id = AsyncHooks.executionAsyncId()
+
+         await hooked_tiny.sql('a.select')
+
+         expect(final_context.preSql.async_id).to.equal(caller_async_execution_id)
       })
    })
 })

--- a/src/test/hooks.ts
+++ b/src/test/hooks.ts
@@ -169,6 +169,37 @@ describe('Hooks', () => {
             })
          })
       })
+
+      describe('name modification', () => {
+         it('should still run the original db_call', async () => {
+            let final_context: any
+
+            const hooks: TinyHooks = {
+               preSql: (ctx, name, params) => {
+                  return { ctx: { ...ctx, foo: 'bar' }, args: [`${name}_foo`, params] }
+               },
+               onResult(ctx, query_complete_context) {
+                  final_context = {
+                     ...ctx,
+                     ...query_complete_context,
+                  }
+
+                  return final_context
+               },
+            }
+
+            const hooks_creation_methods = [H.newTiny({ hooks: hooks }), tiny.withHooks(hooks)]
+
+            for (const my_tiny of hooks_creation_methods) {
+               final_context = null
+
+               await my_tiny.sql('a.select')
+
+               expect(final_context.query_id).to.exist
+               expect(final_context.foo).to.equal('bar')
+            }
+         })
+      })
    })
 
    describe('raw query', () => {

--- a/src/test/hooks.ts
+++ b/src/test/hooks.ts
@@ -96,16 +96,40 @@ describe('Hooks', () => {
             })
          })
 
-         describe('and every hook throws an error', () => {
+         describe('and a pre hook throws an error', () => {
+            it('should throw an error', async () => {
+               const hooks: TinyHooks = {
+                  preSql: (_ctx, _name, _params) => {
+                     throw new Error('Boom')
+                  },
+               }
+
+               const hooks_creation_methods = [H.newTiny({ hooks: hooks }), tiny.withHooks(hooks)]
+
+               for (const my_tiny of hooks_creation_methods) {
+                  try {
+                     await my_tiny.sql('a.select')
+                     expect.fail()
+                  } catch (error) {
+                     expect(error).to.be.instanceOf(Error)
+                  }
+               }
+            })
+         })
+
+         describe('and every non-pre hook throws an error', () => {
             it('should catch the errors and return the original ctx', async () => {
                let final_context: any
                let original_context: any
 
                const hooks: TinyHooks = {
-                  preSql: (ctx, _name, _params) => {
+                  preSql: (ctx, name, params) => {
                      original_context = ctx
 
-                     throw new Error('Error in preSql')
+                     return {
+                        ctx: ctx,
+                        args: [name, params],
+                     }
                   },
                   onQuery(_ctx, _query_begin_context) {
                      throw new Error('Error in onQuery')
@@ -132,7 +156,7 @@ describe('Hooks', () => {
             })
          })
 
-         describe('and a single hook throws an error', () => {
+         describe('and a single non-pre hook throws an error', () => {
             it('should catch the error and continue with the rest of the hooks', async () => {
                let final_context: any
 
@@ -276,16 +300,40 @@ describe('Hooks', () => {
             })
          })
 
-         describe('and every hook throws an error', () => {
+         describe('and a pre hook throws an error', () => {
+            it('should throw an error', async () => {
+               const hooks: TinyHooks = {
+                  preRawQuery: (_ctx, _name, _params) => {
+                     throw new Error('Boom')
+                  },
+               }
+
+               const hooks_creation_methods = [H.newTiny({ hooks: hooks }), tiny.withHooks(hooks)]
+
+               for (const my_tiny of hooks_creation_methods) {
+                  try {
+                     await my_tiny.query('SELECT * FROM __tiny_test_db.a')
+                     expect.fail()
+                  } catch (error) {
+                     expect(error).to.be.instanceOf(Error)
+                  }
+               }
+            })
+         })
+
+         describe('and every non-pre hook throws an error', () => {
             it('should catch the errors and return the original ctx', async () => {
                let final_context: any
                let original_context: any
 
                const hooks: TinyHooks = {
-                  preRawQuery: (ctx, _name, _params) => {
+                  preRawQuery: (ctx, name, params) => {
                      original_context = ctx
 
-                     throw new Error('Error in preRawQuery')
+                     return {
+                        ctx: ctx,
+                        args: [name, params],
+                     }
                   },
                   onQuery(_ctx, _query_begin_context) {
                      throw new Error('Error in onQuery')
@@ -312,7 +360,7 @@ describe('Hooks', () => {
             })
          })
 
-         describe('and a single hook throws an error', () => {
+         describe('and a non-pre single hook throws an error', () => {
             it('should catch the error and continue with the rest of the hooks', async () => {
                let final_context: any
 

--- a/src/test/hooks.ts
+++ b/src/test/hooks.ts
@@ -3,7 +3,10 @@ import { expect } from 'chai'
 import { TinyPg } from '../'
 import * as AsyncHooks from 'async_hooks'
 
-describe.only('Hooks', () => {
+// forces PromiseHooks to be enabled.
+AsyncHooks.createHook({ init() {} }).enable()
+
+describe('Hooks', () => {
    let tiny: TinyPg
 
    beforeEach(() => {
@@ -78,6 +81,7 @@ describe.only('Hooks', () => {
 
          await hooked_tiny.sql('a.select')
 
+         expect(caller_async_execution_id).to.not.equal(0)
          expect(final_context.preSql.async_id).to.equal(caller_async_execution_id)
       })
    })

--- a/src/test/hooks.ts
+++ b/src/test/hooks.ts
@@ -2,6 +2,8 @@ import * as H from './helper'
 import { expect } from 'chai'
 import { TinyPg } from '../'
 import * as AsyncHooks from 'async_hooks'
+import { TinyHooks } from '../types'
+import * as _ from 'lodash'
 
 // forces PromiseHooks to be enabled.
 AsyncHooks.createHook({ init() {} }).enable()
@@ -20,12 +22,10 @@ describe('Hooks', () => {
    })
 
    describe('preSql', () => {
-      describe('options', () => {})
-      describe('withHooks', () => {
-         it('should thread context', async () => {
-            let final_context = null
-
-            const my_tiny = tiny.withHooks({
+      describe('context', () => {
+         it('should thread context (withHooks and via options)', async () => {
+            let final_context: any
+            const hooks: TinyHooks = {
                preSql: (ctx, name, params) => {
                   return { ctx: { ...ctx, foo: 'bar' }, args: [name, params] }
                },
@@ -39,14 +39,133 @@ describe('Hooks', () => {
                   final_context = { ...ctx, onResult: query_complete_context }
                   return final_context
                },
+            }
+
+            const hooks_creation_methods = [H.newTiny({ hooks: hooks }), tiny.withHooks(hooks)]
+
+            for (const my_tiny of hooks_creation_methods) {
+               final_context = null
+
+               await my_tiny.sql('a.select')
+
+               expect(final_context.query_id).to.exist
+               expect(final_context.foo).to.equal('bar')
+               expect(final_context.onQuery).to.exist
+               expect(final_context.onSubmit).to.exist
+               expect(final_context.onResult).to.exist
+            }
+         })
+
+         describe('and there is a transaction', () => {
+            it('should keep the same transaction_id across multiple sql calls', async () => {
+               let transaction_ids = []
+               let query_ids = []
+
+               const hooks: TinyHooks = {
+                  preSql: (ctx, name, params) => {
+                     transaction_ids.push(ctx.transaction_id)
+                     query_ids.push(ctx.query_id)
+                     return { ctx: { ...ctx, foo: 'bar' }, args: [name, params] }
+                  },
+                  onQuery(ctx, query_begin_context) {
+                     return { ...ctx, onQuery: query_begin_context }
+                  },
+                  onSubmit(ctx, query_submit_context) {
+                     return { ...ctx, onSubmit: query_submit_context }
+                  },
+                  onResult(ctx, query_complete_context) {
+                     return { ...ctx, onResult: query_complete_context }
+                  },
+               }
+
+               const my_tiny = tiny.withHooks(hooks)
+
+               await my_tiny.transaction(async tx_db => {
+                  await tx_db.sql('a.select')
+                  await tx_db.sql('a.select')
+               })
+
+               const unique_transaction_ids = _.uniq(transaction_ids)
+               const unique_query_ids = _.uniq(query_ids)
+
+               expect(unique_transaction_ids).to.have.length(1)
+               expect(_.isString(unique_transaction_ids[0])).to.be.true
+               expect(unique_query_ids).to.have.length(2)
             })
+         })
+      })
+   })
 
-            await my_tiny.sql('a.select')
+   describe('raw query', () => {
+      describe('context', () => {
+         it('should thread context (withHooks and via options)', async () => {
+            let final_context: any
+            const hooks: TinyHooks = {
+               preRawQuery: (ctx, name, params) => {
+                  return { ctx: { ...ctx, foo: 'bar' }, args: [name, params] }
+               },
+               onQuery(ctx, query_begin_context) {
+                  return { ...ctx, onQuery: query_begin_context }
+               },
+               onSubmit(ctx, query_submit_context) {
+                  return { ...ctx, onSubmit: query_submit_context }
+               },
+               onResult(ctx, query_complete_context) {
+                  final_context = { ...ctx, onResult: query_complete_context }
+                  return final_context
+               },
+            }
 
-            expect(final_context.foo).to.equal('bar')
-            expect(final_context.onQuery).to.exist
-            expect(final_context.onSubmit).to.exist
-            expect(final_context.onResult).to.exist
+            const hooks_creation_methods = [H.newTiny({ hooks: hooks }), tiny.withHooks(hooks)]
+
+            for (const my_tiny of hooks_creation_methods) {
+               final_context = null
+
+               await my_tiny.query('SELECT * FROM __tiny_test_db.a')
+
+               expect(final_context.query_id).to.exist
+               expect(final_context.foo).to.equal('bar')
+               expect(final_context.onQuery).to.exist
+               expect(final_context.onSubmit).to.exist
+               expect(final_context.onResult).to.exist
+            }
+         })
+
+         describe('and there is a transaction', () => {
+            it('should keep the same transaction_id across multiple query calls', async () => {
+               let transaction_ids = []
+               let query_ids = []
+               const hooks: TinyHooks = {
+                  preRawQuery: (ctx, name, params) => {
+                     transaction_ids.push(ctx.transaction_id)
+                     query_ids.push(ctx.query_id)
+                     return { ctx: { ...ctx, foo: 'bar' }, args: [name, params] }
+                  },
+                  onQuery(ctx, query_begin_context) {
+                     return { ...ctx, onQuery: query_begin_context }
+                  },
+                  onSubmit(ctx, query_submit_context) {
+                     return { ...ctx, onSubmit: query_submit_context }
+                  },
+                  onResult(ctx, query_complete_context) {
+                     return { ...ctx, onResult: query_complete_context }
+                  },
+               }
+
+               const my_tiny = tiny.withHooks(hooks)
+
+               await my_tiny.transaction(async tx_db => {
+                  await tx_db.query('SELECT * FROM __tiny_test_db.a')
+                  await tx_db.query('SELECT * FROM __tiny_test_db.a')
+               })
+
+               const unique_transaction_ids = _.uniq(transaction_ids)
+               const unique_query_ids = _.uniq(query_ids)
+
+               expect(unique_transaction_ids).to.have.length(1)
+               expect(_.isString(unique_transaction_ids[0])).to.be.true
+               expect(unique_query_ids).to.have.length(2)
+            })
          })
       })
    })

--- a/src/tiny.ts
+++ b/src/tiny.ts
@@ -203,7 +203,7 @@ export class TinyPg {
                   }
 
                   const [name, params] = last_result.args
-                  const result = hook_set_with_ctx.hook_set.preSql(hook_set_with_ctx.ctx, name, params)
+                  const result = hook_set_with_ctx.hook_set.preSql(ctx, name, params)
                   hook_set_with_ctx.ctx = result.ctx
                   return result
                },
@@ -217,7 +217,7 @@ export class TinyPg {
                      return last_result
                   }
                   const [raw_query, params] = last_result.args
-                  const result = hook_set_with_ctx.hook_set.preRawQuery(hook_set_with_ctx.ctx, raw_query, params)
+                  const result = hook_set_with_ctx.hook_set.preRawQuery(ctx, raw_query, params)
                   hook_set_with_ctx.ctx = result.ctx
                   return result
                },

--- a/src/tiny.ts
+++ b/src/tiny.ts
@@ -202,10 +202,19 @@ export class TinyPg {
                      return last_result
                   }
 
-                  const [name, params] = last_result.args
-                  const result = hook_set_with_ctx.hook_set.preSql(ctx, name, params)
-                  hook_set_with_ctx.ctx = result.ctx
-                  return result
+                  try {
+                     const [name, params] = last_result.args
+
+                     const result = hook_set_with_ctx.hook_set.preSql(ctx, name, params)
+
+                     hook_set_with_ctx.ctx = result.ctx
+
+                     return result
+                  } catch (error) {
+                     log('preSql hook error', error)
+
+                     return last_result
+                  }
                },
                { args: args, ctx: ctx }
             )
@@ -216,10 +225,20 @@ export class TinyPg {
                   if (_.isNil(hook_set_with_ctx.hook_set.preRawQuery)) {
                      return last_result
                   }
-                  const [raw_query, params] = last_result.args
-                  const result = hook_set_with_ctx.hook_set.preRawQuery(ctx, raw_query, params)
-                  hook_set_with_ctx.ctx = result.ctx
-                  return result
+
+                  try {
+                     const [raw_query, params] = last_result.args
+
+                     const result = hook_set_with_ctx.hook_set.preRawQuery(ctx, raw_query, params)
+
+                     hook_set_with_ctx.ctx = result.ctx
+
+                     return result
+                  } catch (error) {
+                     log('preRawQuery hook error', error)
+
+                     return last_result
+                  }
                },
                { args: args, ctx: ctx }
             )
@@ -229,7 +248,12 @@ export class TinyPg {
                if (_.isNil(hook_set_with_ctx.hook_set.onSubmit)) {
                   return
                }
-               hook_set_with_ctx.ctx = hook_set_with_ctx.hook_set.onSubmit(hook_set_with_ctx.ctx, query_submit_context)
+
+               try {
+                  hook_set_with_ctx.ctx = hook_set_with_ctx.hook_set.onSubmit(hook_set_with_ctx.ctx, query_submit_context)
+               } catch (error) {
+                  log('onSubmit hook error', error)
+               }
             })
          },
          onQuery: (query_begin_context: T.QueryBeginContext) => {
@@ -237,7 +261,12 @@ export class TinyPg {
                if (_.isNil(hook_set_with_ctx.hook_set.onQuery)) {
                   return
                }
-               hook_set_with_ctx.ctx = hook_set_with_ctx.hook_set.onQuery(hook_set_with_ctx.ctx, query_begin_context)
+
+               try {
+                  hook_set_with_ctx.ctx = hook_set_with_ctx.hook_set.onQuery(hook_set_with_ctx.ctx, query_begin_context)
+               } catch (error) {
+                  log('onQuery hook error', error)
+               }
             })
          },
          onResult: (query_complete_context: T.QueryCompleteContext) => {
@@ -245,7 +274,12 @@ export class TinyPg {
                if (_.isNil(hook_set_with_ctx.hook_set.onResult)) {
                   return
                }
-               hook_set_with_ctx.ctx = hook_set_with_ctx.hook_set.onResult(hook_set_with_ctx.ctx, query_complete_context)
+
+               try {
+                  hook_set_with_ctx.ctx = hook_set_with_ctx.hook_set.onResult(hook_set_with_ctx.ctx, query_complete_context)
+               } catch (error) {
+                  log('onResult hook error', error)
+               }
             })
          },
       }

--- a/src/tiny.ts
+++ b/src/tiny.ts
@@ -221,21 +221,13 @@ export class TinyPg {
                   return last_result
                }
 
-               try {
-                  const [name_or_query, params] = last_result.args
+               const [name_or_query, params] = last_result.args
 
-                  const result = hook_fn(ctx, name_or_query, params)
+               const result = hook_fn(ctx, name_or_query, params)
 
-                  hook_set_with_ctx.ctx = result.ctx
+               hook_set_with_ctx.ctx = result.ctx
 
-                  return result
-               } catch (error) {
-                  log(`${fn_name} hook error`, error)
-
-                  hook_set_with_ctx.ctx = last_result.ctx
-
-                  return last_result
-               }
+               return result
             },
             { args: args, ctx: ctx }
          )

--- a/src/tiny.ts
+++ b/src/tiny.ts
@@ -107,15 +107,15 @@ export class TinyPg {
 
       const hook_lifecycle = this.makeHooksLifeCycle()
 
-      const [new_name, new_params] = hook_lifecycle.preSql({ query_id: query_id, transaction_id: this.transaction_id }, [name, params]).args
+      const [, new_params] = hook_lifecycle.preSql({ query_id: query_id, transaction_id: this.transaction_id }, [name, params]).args
 
       return Util.stackTraceAccessor(this.options.capture_stack_trace, async () => {
-         log('sql', new_name)
+         log('sql', name)
 
-         const db_call: DbCall = this.sql_db_calls[new_name]
+         const db_call: DbCall = this.sql_db_calls[name]
 
          if (_.isNil(db_call)) {
-            throw new Error(`Sql query with name [${new_name}] not found!`)
+            throw new Error(`Sql query with name [${name}] not found!`)
          }
 
          return this.performDbCall<T>(db_call, hook_lifecycle, new_params, query_id)

--- a/src/tiny.ts
+++ b/src/tiny.ts
@@ -240,7 +240,7 @@ export class TinyPg {
          _.forEach(hooks_to_run, hook_set_with_ctx => {
             const hook_fn: any = hook_set_with_ctx.hook_set[fn_name]
 
-            if (_.isNil(_.isNil(hook_fn) || !_.isFunction(hook_fn))) {
+            if (_.isNil(hook_fn) || !_.isFunction(hook_fn)) {
                return
             }
 

--- a/src/tiny.ts
+++ b/src/tiny.ts
@@ -334,9 +334,7 @@ export class TinyPg {
          let error: any = null
 
          try {
-            // Query hook
-            // begin_context.caller_context = this.runQueryHooks(this.hook_collection.onQuery, begin_context)
-
+            hooks.onQuery(begin_context)
             this.events.emit('query', begin_context)
 
             log('executing', db_call.config.name)
@@ -363,9 +361,7 @@ export class TinyPg {
                const submitted_at = Date.now()
                submit_context = { ...begin_context, submit: submitted_at, wait_duration: submitted_at - begin_context.start }
 
-               // Submit hook
                hooks.onSubmit(submit_context)
-
                this.events.emit('submit', submit_context)
                original_submit.call(query, connection)
             }

--- a/src/tiny.ts
+++ b/src/tiny.ts
@@ -303,7 +303,7 @@ export class TinyPg {
                }
 
                try {
-                  hook_set_with_ctx.transaction_ctx = hook_set_with_ctx.hook_set.preTransaction(hook_set_with_ctx.transaction_ctx, transaction_id)
+                  hook_set_with_ctx.transaction_ctx = hook_set_with_ctx.hook_set.preTransaction(transaction_id)
                } catch (error) {
                   log('preTransaction hook error', error)
                }

--- a/src/tiny.ts
+++ b/src/tiny.ts
@@ -227,6 +227,8 @@ export class TinyPg {
                   } catch (error) {
                      log('preSql hook error', error)
 
+                     hook_set_with_ctx.ctx = last_result.ctx
+
                      return last_result
                   }
                },
@@ -250,6 +252,8 @@ export class TinyPg {
                      return result
                   } catch (error) {
                      log('preRawQuery hook error', error)
+
+                     hook_set_with_ctx.ctx = last_result.ctx
 
                      return last_result
                   }

--- a/src/tiny.ts
+++ b/src/tiny.ts
@@ -359,7 +359,6 @@ export class TinyPg {
       query_id?: string
    ): Promise<T.Result<T>> {
       log('performDbCall', db_call.config.name)
-      // pass in outside ctx from hoo
 
       let call_completed = false
       let client: Pg.PoolClient
@@ -538,9 +537,8 @@ export class FormattableDbCall {
    }
 
    query<T extends object = any>(params: T.TinyPgParams = {}): Promise<T.Result<T>> {
-      //const query_id = Uuid.v4()
       const hook_lifecycle = this.db.makeHooksLifeCycle()
-      // hook_lifecycle.preRawQuery({ query_id: query_id }, this.db_call.config.)
+
       return this.db.performDbCall<T>(this.db_call, hook_lifecycle, params)
    }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,27 +15,39 @@ export interface PreRawQueryHookResult {
    caller_context: any
 }
 
-export type TransactionContext = { transaction_id: string }
-export type QueryContext = { query_id: string }
-
-export type TinyCallContext = TransactionContext | QueryContext
+export interface TinyCallContext {
+   transaction_id: string
+   query_id: string
+}
 
 export interface TinyHookLifecycle {
    preSql?: (tiny_ctx: TinyCallContext, params: [string, TinyPgParams]) => HookResult<[string, TinyPgParams]>
    preRawQuery?: (tiny_ctx: TinyCallContext, params: [string, TinyPgParams]) => HookResult<[string, TinyPgParams]>
-   // // TODO transaction
    onQuery?: (query_begin_context: QueryBeginContext) => void
    onSubmit?: (query_submit_context: QuerySubmitContext) => void
    onResult?: (query_complete_context: QueryCompleteContext) => void
+   preTransaction?: (transaction_id: string) => void
+   onBegin?: (transaction_id: string) => void
+   onCommit?: (transaction_id: string) => void
+   onRollback?: (transaction_id: string, error: Error) => void
 }
 
 export interface TinyHooks {
    preSql?: (tiny_ctx: TinyCallContext, name: string, params: TinyPgParams) => HookResult<[string, TinyPgParams]>
    preRawQuery?: (tiny_ctx: TinyCallContext, name: string, params: TinyPgParams) => HookResult<[string, TinyPgParams]>
-   // // TODO transaction
    onQuery?: (ctx: any, query_begin_context: QueryBeginContext) => any
    onSubmit?: (ctx: any, query_submit_context: QuerySubmitContext) => any
    onResult?: (ctx: any, query_complete_context: QueryCompleteContext) => any
+   preTransaction?: (transaction_ctx: any, transaction_id: string) => void
+   onBegin?: (transaction_ctx: any, transaction_id: string) => void
+   onCommit?: (transaction_ctx: any, transaction_id: string) => void
+   onRollback?: (transaction_ctx: any, transaction_id: string, error: Error) => void
+}
+
+export interface HookSetWithContext {
+   ctx: any
+   transaction_ctx: any
+   hook_set: TinyHooks
 }
 
 export interface TinyPgOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,7 @@ export interface TinyHookLifecycle {
 
 export interface TinyHooks {
    preSql?: (tiny_ctx: TinyCallContext, name: string, params: TinyPgParams) => HookResult<[string, TinyPgParams]>
-   preRawQuery?: (tiny_ctx: TinyCallContext, name: string, params: TinyPgParams) => HookResult<[string, TinyPgParams]>
+   preRawQuery?: (tiny_ctx: TinyCallContext, query: string, params: TinyPgParams) => HookResult<[string, TinyPgParams]>
    onQuery?: (ctx: any, query_begin_context: QueryBeginContext) => any
    onSubmit?: (ctx: any, query_submit_context: QuerySubmitContext) => any
    onResult?: (ctx: any, query_complete_context: QueryCompleteContext) => any

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,10 @@ import { EventEmitter } from 'events'
 import { TinyPgErrorTransformer } from './errors'
 import { TlsOptions } from 'tls'
 
+export interface TinyHooks {
+   preSql: (name: string, params: any) => [string, any]
+}
+
 export interface TinyPgOptions {
    connection_string: string
    tls_options?: TlsOptions
@@ -9,6 +13,7 @@ export interface TinyPgOptions {
    use_prepared_statements?: boolean
    error_transformer?: TinyPgErrorTransformer
    capture_stack_trace?: boolean
+   hooks: TinyHooks
    pool_options?: {
       max?: number
       min?: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,7 +38,7 @@ export interface TinyHooks {
    onQuery?: (ctx: any, query_begin_context: QueryBeginContext) => any
    onSubmit?: (ctx: any, query_submit_context: QuerySubmitContext) => any
    onResult?: (ctx: any, query_complete_context: QueryCompleteContext) => any
-   preTransaction?: (transaction_ctx: any, transaction_id: string) => void
+   preTransaction?: (transaction_id: string) => void
    onBegin?: (transaction_ctx: any, transaction_id: string) => void
    onCommit?: (transaction_ctx: any, transaction_id: string) => void
    onRollback?: (transaction_ctx: any, transaction_id: string, error: Error) => void

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,10 +38,10 @@ export interface TinyHooks {
    onQuery?: (ctx: any, query_begin_context: QueryBeginContext) => any
    onSubmit?: (ctx: any, query_submit_context: QuerySubmitContext) => any
    onResult?: (ctx: any, query_complete_context: QueryCompleteContext) => any
-   preTransaction?: (transaction_id: string) => void
-   onBegin?: (transaction_ctx: any, transaction_id: string) => void
-   onCommit?: (transaction_ctx: any, transaction_id: string) => void
-   onRollback?: (transaction_ctx: any, transaction_id: string, error: Error) => void
+   preTransaction?: (transaction_id: string) => any
+   onBegin?: (transaction_ctx: any, transaction_id: string) => any
+   onCommit?: (transaction_ctx: any, transaction_id: string) => any
+   onRollback?: (transaction_ctx: any, transaction_id: string, error: Error) => any
 }
 
 export interface HookSetWithContext {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,8 +2,27 @@ import { EventEmitter } from 'events'
 import { TinyPgErrorTransformer } from './errors'
 import { TlsOptions } from 'tls'
 
+export type HookCollection = { [P in keyof Required<TinyHooks>]: TinyHooks[P][] }
+
+export interface PreSqlHookResult {
+   name: string
+   params: TinyPgParams
+   caller_context: any
+}
+
+export interface PreRawQueryHookResult {
+   raw_sql: string
+   params: TinyPgParams
+   caller_context: any
+}
+
 export interface TinyHooks {
-   preSql: (name: string, params: any) => [string, any]
+   preSql?: (name: string, query_id: string, params?: TinyPgParams, context?: any) => PreSqlHookResult
+   preRawQuery?: (rawSql: string, query_id: string, params?: TinyPgParams, context?: any) => PreRawQueryHookResult
+   // TODO transaction
+   onQuery?: (query_begin_context: QueryBeginContext) => any
+   onSubmit?: (query_submit_context: QuerySubmitContext) => any
+   onResult?: (query_complete_context: QueryCompleteContext) => any
 }
 
 export interface TinyPgOptions {
@@ -35,7 +54,11 @@ export interface Result<T extends object> {
    row_count: number
 }
 
-export interface QueryBeginContext {
+export interface ContextCallable {
+   caller_context?: any
+}
+
+export interface QueryBeginContext extends ContextCallable {
    id: string
    sql: string
    start: number


### PR DESCRIPTION
TODO:
- [x] Support transaction hooks & context passing to `sql` and `query`
- [x] Catch hook errors as a noop and pass previous context
- [x] Tests for transaction hooks catching errors
- [x] Clean up api (duplication in hooks lifecycle)
- [x] Documentation
